### PR TITLE
Split up framework arg when branch is included

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -11,11 +11,12 @@ var yosay   = require('yosay');
 var EvolveGenerator = yeoman.generators.Base.extend({
   init: function() {
     if (this.args.length) {
-      this.framework = this.args[0];
-    }
-
-    if (this.framework && this.framework.indexOf('#') > 0) {
-      this.branch = this.framework.split('#').pop() || 'master';
+      if (this.args[0].indexOf('#') > 0) {
+        this.branch     = this.args[0].split('#')[1];
+        this.framework  = this.args[0].split('#')[0];
+      } else {
+        this.framework  = this.args[0];
+      }
     }
   },
 


### PR DESCRIPTION
When including a branch in the framework argument the `framework` object was including the branch resulting in an error fetching the remote files (ex. https://gist.github.com/jimmynotjim/b3305722be643af60f83#file-gistfile1-txt-L6).
### Changes
- Split out `branch` and `framework` objects when a branch is present in the passed argument
- Defaulted `framework` object when no branch is present in the passed argument
### Testing
- Run `yo evolved wordpress#7-core-theme` and should pull from `7-core-theme` branch
  
  ``` bash
  info ... Fetching http://github.com/evolution/wordpress/archive/7-core-theme.tar.gz ...
  ```
- Run `yo evolved wordpress` and should pull from latest release (currently v1.0.10)
  
  ``` bash
  info ... Fetching http://github.com/evolution/wordpress/archive/v1.0.10.tar.gz ...
  ```
### Review

@ericclemmons
@EvanK 
